### PR TITLE
受講生情報更新&論理削除処理を実装

### DIFF
--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -25,8 +25,8 @@ public class StudentController {
 
   @GetMapping("/allStudentAndCourseList")
   public String getAllStudentAndCourseList(Model model) {
-    model.addAttribute("studentList", service.selectAllStudentList());
-    model.addAttribute("courseList", service.selectAllStudentsCourseList());
+    model.addAttribute("studentList", service.selectActiveStudentList());
+    model.addAttribute("courseList", service.selectActiveCourseList());
     return "studentAndCourseList";
   }
 

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -7,6 +7,7 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import reisetech.StudentManagement.data.StudentsCourses;
 import reisetech.StudentManagement.domain.StudentDetail;
@@ -45,6 +46,14 @@ public class StudentController {
     service.registerStudent(studentDetail);
     service.registerCourse(studentDetail);
     return "redirect:/allStudentAndCourseList";
+  }
+
+  @GetMapping("/displayStudent/{studentId}")
+  public String searchStudentById(@PathVariable String studentId, Model model) {
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail = service.searchStudentDetail(studentId);
+    model.addAttribute("studentDetail", studentDetail);
+    return "updateStudent";
   }
 
 }

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -34,9 +34,6 @@ public class StudentController {
   public String getStudent(@PathVariable int studentId, Model model) {
     StudentDetail studentDetail = service.searchStudentDetail(studentId);
     model.addAttribute("studentDetail", studentDetail);
-    StudentsCourses studentsCourses = new StudentsCourses();
-    studentsCourses.setStudentId(studentId);
-    model.addAttribute("additionalCourse", studentsCourses);
     return "updateStudent";
   }
 

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -56,4 +56,15 @@ public class StudentController {
     return "updateStudent";
   }
 
+  @PostMapping("/updateStudent")
+  public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "updateStudent";
+    }
+    service.updateStudent(studentDetail);
+    service.updateCourses(studentDetail);
+    return "redirect:/allStudentAndCourseList";
+  }
+
+
 }

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import reisetech.StudentManagement.data.Student;
 import reisetech.StudentManagement.data.StudentsCourses;
 import reisetech.StudentManagement.domain.StudentDetail;
 import reisetech.StudentManagement.service.StudentService;
@@ -23,11 +24,33 @@ public class StudentController {
     this.service = service;
   }
 
-  @GetMapping("/allStudentAndCourseList")
-  public String getAllStudentAndCourseList(Model model) {
+  @GetMapping("/activeStudentAndCourseList")
+  public String getActiveStudentAndCourseList(Model model) {
     model.addAttribute("studentList", service.selectActiveStudentList());
     model.addAttribute("courseList", service.selectActiveCourseList());
     return "studentAndCourseList";
+  }
+
+  @GetMapping("/deletedStudentList")
+  public String getDeletedStudentList(Model model) {
+    model.addAttribute("studentList", service.selectInactiveStudentList());
+    return "deletedStudentList";
+  }
+
+  @GetMapping("/deletedStudent/{studentId}")
+  public String getDeletedStudent(@PathVariable int studentId, Model model) {
+    StudentDetail studentDetail = service.searchStudentDetail(studentId);
+    model.addAttribute("student", studentDetail.getStudent());
+    return "activateStudent";
+  }
+
+  @PostMapping("/activateStudent")
+  public String activateStudent(@ModelAttribute Student student, BindingResult result) {
+    if (result.hasErrors()) {
+      return "activateStudent";
+    }
+    service.switchStudent(student);
+    return "redirect:/activeStudentAndCourseList";
   }
 
   @GetMapping("/student/{studentId}")
@@ -55,7 +78,7 @@ public class StudentController {
     }
     service.registerStudent(studentDetail);
     service.registerCourse(studentDetail);
-    return "redirect:/allStudentAndCourseList";
+    return "redirect:/activeStudentAndCourseList";
   }
 
   @PostMapping("/updateStudent")
@@ -65,7 +88,7 @@ public class StudentController {
     }
     service.updateStudent(studentDetail);
     service.updateCourses(studentDetail);
-    return "redirect:/allStudentAndCourseList";
+    return "redirect:/activeStudentAndCourseList";
   }
 
   @PostMapping("/addCourse")
@@ -75,7 +98,7 @@ public class StudentController {
       return "updateStudent";
     }
     service.addCourse(additionalCourse);
-    return "redirect:/allStudentAndCourseList";
+    return "redirect:/activeStudentAndCourseList";
   }
 
 

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -30,6 +30,16 @@ public class StudentController {
     return "studentAndCourseList";
   }
 
+  @GetMapping("/student/{studentId}")
+  public String getStudent(@PathVariable int studentId, Model model) {
+    StudentDetail studentDetail = service.searchStudentDetail(studentId);
+    model.addAttribute("studentDetail", studentDetail);
+    StudentsCourses studentsCourses = new StudentsCourses();
+    studentsCourses.setStudentId(studentId);
+    model.addAttribute("additionalCourse", studentsCourses);
+    return "updateStudent";
+  }
+
   @GetMapping("/newStudent")
   public String newStudent(Model model) {
     StudentDetail studentDetail = new StudentDetail();
@@ -48,14 +58,6 @@ public class StudentController {
     return "redirect:/allStudentAndCourseList";
   }
 
-  @GetMapping("/displayStudent/{studentId}")
-  public String searchStudentById(@PathVariable String studentId, Model model) {
-    StudentDetail studentDetail = new StudentDetail();
-    studentDetail = service.searchStudentDetail(studentId);
-    model.addAttribute("studentDetail", studentDetail);
-    return "updateStudent";
-  }
-
   @PostMapping("/updateStudent")
   public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
     if (result.hasErrors()) {
@@ -63,6 +65,16 @@ public class StudentController {
     }
     service.updateStudent(studentDetail);
     service.updateCourses(studentDetail);
+    return "redirect:/allStudentAndCourseList";
+  }
+
+  @PostMapping("/addCourse")
+  public String addCourse(@ModelAttribute StudentsCourses additionalCourse,
+      BindingResult result) {
+    if (result.hasErrors()) {
+      return "updateStudent";
+    }
+    service.addCourse(additionalCourse);
     return "redirect:/allStudentAndCourseList";
   }
 

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -34,6 +34,9 @@ public class StudentController {
   public String getStudent(@PathVariable int studentId, Model model) {
     StudentDetail studentDetail = service.searchStudentDetail(studentId);
     model.addAttribute("studentDetail", studentDetail);
+    StudentsCourses studentsCourses = new StudentsCourses();
+    studentsCourses.setStudentId(studentId);
+    model.addAttribute("additionalCourse", studentsCourses);
     return "updateStudent";
   }
 

--- a/src/main/java/reisetech/StudentManagement/data/Student.java
+++ b/src/main/java/reisetech/StudentManagement/data/Student.java
@@ -17,6 +17,6 @@ public class Student {
   private int age;
   private String gender;
   private String remark;
-  private boolean isDeleted;
+  private int isDeleted;
 
 }

--- a/src/main/java/reisetech/StudentManagement/data/Student.java
+++ b/src/main/java/reisetech/StudentManagement/data/Student.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Getter//lombokが勝手に作ってくれる
 public class Student {
 
-  private String studentId;
+  private int studentId;
   private String fullname;
   private String kanaName;
   private String nickname;

--- a/src/main/java/reisetech/StudentManagement/data/StudentsCourses.java
+++ b/src/main/java/reisetech/StudentManagement/data/StudentsCourses.java
@@ -8,9 +8,9 @@ import lombok.Setter;
 @Getter
 public class StudentsCourses {
 
-  private String courseId;
+  private int courseId;
   private String courseName;
-  private String studentId;
+  private int studentId;
   private LocalDate courseStartAt;
   private LocalDate courseEndAt;
 }

--- a/src/main/java/reisetech/StudentManagement/data/StudentsCourses.java
+++ b/src/main/java/reisetech/StudentManagement/data/StudentsCourses.java
@@ -13,4 +13,5 @@ public class StudentsCourses {
   private int studentId;
   private LocalDate courseStartAt;
   private LocalDate courseEndAt;
+  private int isDeleted;
 }

--- a/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
@@ -12,11 +12,11 @@ import reisetech.StudentManagement.data.StudentsCourses;
 @Mapper
 public interface StudentRepository {
 
-  @Select("SELECT * FROM students")
-  List<Student> searchStudentList();
+  @Select("SELECT * FROM students WHERE is_deleted = 0")
+  List<Student> searchActiveStudentList();
 
-  @Select("SELECT * FROM students_courses")
-  List<StudentsCourses> searchStudentsCourseList();
+  @Select("SELECT * FROM students_courses WHERE is_deleted = 0")
+  List<StudentsCourses> searchActiveCourseList();
 
   @Select("SELECT * FROM students WHERE student_id=#{studentId}")
   Student searchStudentByStudentId(int studentId);

--- a/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
@@ -13,11 +13,16 @@ import reisetech.StudentManagement.data.StudentsCourses;
 public interface StudentRepository {
 
   @Select("SELECT * FROM students")
-  List<Student> search();
+  List<Student> searchStudentList();
 
   @Select("SELECT * FROM students_courses")
-  List<StudentsCourses> searchStudentsCourses();
+  List<StudentsCourses> searchStudentsCourseList();
 
+  @Select("SELECT * FROM students WHERE student_id=#{studentId}")
+  Student searchStudentByStudentId(int studentId);
+
+  @Select("SELECT * FROM students_courses WHERE student_id=#{studentId}")
+  List<StudentsCourses> searchCoursesByStudentId(int studentId);
 
   @Insert(
       "INSERT INTO students (fullname, kana_name, nickname, email, city, telephone, age, gender, remark, is_deleted) "
@@ -32,12 +37,6 @@ public interface StudentRepository {
   @Options(useGeneratedKeys = true, keyProperty = "courseId")
   void registerCourse(StudentsCourses courses);
 
-
-  @Select("SELECT * FROM students WHERE student_id=#{studentId}")
-  Student searchStudentByStudentId(String studentId);
-
-  @Select("SELECT * FROM students_courses WHERE student_id=#{studentId}")
-  List<StudentsCourses> searchCoursesByStudentId(String studentId);
 
   @Update("UPDATE students SET "
       + "fullname=#{fullname}, kana_name=#{kanaName}, nickname=#{nickname}, email=#{email}, city=#{city},"

--- a/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
@@ -18,6 +18,9 @@ public interface StudentRepository {
   @Select("SELECT * FROM students_courses WHERE is_deleted = 0")
   List<StudentsCourses> searchActiveCourseList();
 
+  @Select("SELECT * FROM students WHERE is_deleted = 1")
+  List<Student> searchInactiveStudentList();
+
   @Select("SELECT * FROM students WHERE student_id=#{studentId}")
   Student searchStudentByStudentId(int studentId);
 
@@ -48,5 +51,9 @@ public interface StudentRepository {
       + "course_name=#{courseName}, course_start_at=#{courseStartAt}, course_end_at=#{courseEndAt}"
       + "WHERE course_id=#{courseId}")
   void updateCourse(StudentsCourses courses);
+
+  @Update("UPDATE students SET is_deleted=#{isDeleted} WHERE student_id=#{studentId}")
+  void switchStudent(int studentId, int isDeleted);
+
 
 }

--- a/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import reisetech.StudentManagement.data.Student;
 import reisetech.StudentManagement.data.StudentsCourses;
 
@@ -17,11 +18,6 @@ public interface StudentRepository {
   @Select("SELECT * FROM students_courses")
   List<StudentsCourses> searchStudentsCourses();
 
-  @Select("SELECT * FROM students WHERE student_id=#{studentId}")
-  Student searchStudentByStudentId(String studentId);
-
-  @Select("SELECT * FROM students_courses WHERE student_id=#{studentId}")
-  List<StudentsCourses> searchCoursesByStudentId(String studentId);
 
   @Insert(
       "INSERT INTO students (fullname, kana_name, nickname, email, city, telephone, age, gender, remark, is_deleted) "
@@ -35,4 +31,23 @@ public interface StudentRepository {
           + "VALUES (#{courseName},#{studentId},#{courseStartAt},#{courseEndAt});")
   @Options(useGeneratedKeys = true, keyProperty = "courseId")
   void registerCourse(StudentsCourses courses);
+
+
+  @Select("SELECT * FROM students WHERE student_id=#{studentId}")
+  Student searchStudentByStudentId(String studentId);
+
+  @Select("SELECT * FROM students_courses WHERE student_id=#{studentId}")
+  List<StudentsCourses> searchCoursesByStudentId(String studentId);
+
+  @Update("UPDATE students SET "
+      + "fullname=#{fullname}, kana_name=#{kanaName}, nickname=#{nickname}, email=#{email}, city=#{city},"
+      + " telephone=#{telephone}, age=#{age}, gender=#{gender}, remark=#{remark}, is_deleted=#{isDeleted} "
+      + "WHERE student_id=#{studentId}")
+  void updateStudent(Student student);
+
+  @Update("UPDATE students_courses SET "
+      + "course_name=#{courseName}, course_start_at=#{courseStartAt}, course_end_at=#{courseEndAt}"
+      + "WHERE course_id=#{courseId}")
+  void updateCourse(StudentsCourses courses);
+
 }

--- a/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/reisetech/StudentManagement/repository/StudentRepository.java
@@ -17,6 +17,12 @@ public interface StudentRepository {
   @Select("SELECT * FROM students_courses")
   List<StudentsCourses> searchStudentsCourses();
 
+  @Select("SELECT * FROM students WHERE student_id=#{studentId}")
+  Student searchStudentByStudentId(String studentId);
+
+  @Select("SELECT * FROM students_courses WHERE student_id=#{studentId}")
+  List<StudentsCourses> searchCoursesByStudentId(String studentId);
+
   @Insert(
       "INSERT INTO students (fullname, kana_name, nickname, email, city, telephone, age, gender, remark, is_deleted) "
           + "VALUES (#{fullname}, #{kanaName}, #{nickname},"

--- a/src/main/java/reisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/reisetech/StudentManagement/service/StudentService.java
@@ -22,12 +22,12 @@ public class StudentService {
     this.repository = repository;
   }
 
-  public List<Student> selectAllStudentList() {
-    return repository.searchStudentList();
+  public List<Student> selectActiveStudentList() {
+    return repository.searchActiveStudentList();
   }
 
-  public List<StudentsCourses> selectAllStudentsCourseList() {
-    return repository.searchStudentsCourseList();
+  public List<StudentsCourses> selectActiveCourseList() {
+    return repository.searchActiveCourseList();
   }
 
   @Transactional//サービス層の登録・更新・削除をするメソッドに必ずつける

--- a/src/main/java/reisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/reisetech/StudentManagement/service/StudentService.java
@@ -24,11 +24,11 @@ public class StudentService {
   }
 
   public List<Student> selectAllStudentList() {
-    return repository.search();
+    return repository.searchStudentList();
   }
 
   public List<Student> serchStudentList() {
-    List<Student> allStudents = repository.search();
+    List<Student> allStudents = repository.searchStudentList();
 
     List<Student> filteredStudents = allStudents.stream()
         .filter(student -> student.getAge() >= 30)
@@ -38,11 +38,11 @@ public class StudentService {
   }
 
   public List<StudentsCourses> selectAllStudentsCourseList() {
-    return repository.searchStudentsCourses();
+    return repository.searchStudentsCourseList();
   }
 
   public List<StudentsCourses> searchStudentsCourseList() {
-    List<StudentsCourses> allStudentsCourses = repository.searchStudentsCourses();
+    List<StudentsCourses> allStudentsCourses = repository.searchStudentsCourseList();
 
     List<StudentsCourses> filteredStudentsCourses = allStudentsCourses.stream()
         .filter(courses -> courses.getCourseName().equals("Java"))
@@ -72,7 +72,7 @@ public class StudentService {
   }
 
   @Transactional
-  public StudentDetail searchStudentDetail(String studentId) {
+  public StudentDetail searchStudentDetail(int studentId) {
     StudentDetail studentDetail = new StudentDetail();
 
     Student student = repository.searchStudentByStudentId(studentId);
@@ -95,6 +95,12 @@ public class StudentService {
     for (StudentsCourses course : courses) {
       repository.updateCourse(course);
     }
+  }
+
+  @Transactional
+  public void addCourse(StudentsCourses additionalCourse) {
+    additionalCourse.setCourseEndAt(additionalCourse.getCourseStartAt().plusMonths(6));
+    repository.registerCourse(additionalCourse);
   }
 
 }

--- a/src/main/java/reisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/reisetech/StudentManagement/service/StudentService.java
@@ -30,6 +30,10 @@ public class StudentService {
     return repository.searchActiveCourseList();
   }
 
+  public List<Student> selectInactiveStudentList() {
+    return repository.searchInactiveStudentList();
+  }
+
   @Transactional//サービス層の登録・更新・削除をするメソッドに必ずつける
   public void registerStudent(StudentDetail studentDetail) {
     Student student = studentDetail.getStudent();
@@ -79,6 +83,11 @@ public class StudentService {
   public void addCourse(StudentsCourses additionalCourse) {
     additionalCourse.setCourseEndAt(additionalCourse.getCourseStartAt().plusMonths(6));
     repository.registerCourse(additionalCourse);
+  }
+
+  @Transactional
+  public void switchStudent(Student student) {
+    repository.switchStudent(student.getStudentId(), student.getIsDeleted());
   }
 
 }

--- a/src/main/java/reisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/reisetech/StudentManagement/service/StudentService.java
@@ -2,7 +2,6 @@ package reisetech.StudentManagement.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,29 +26,8 @@ public class StudentService {
     return repository.searchStudentList();
   }
 
-  public List<Student> serchStudentList() {
-    List<Student> allStudents = repository.searchStudentList();
-
-    List<Student> filteredStudents = allStudents.stream()
-        .filter(student -> student.getAge() >= 30)
-        .collect(Collectors.toList());
-
-    return filteredStudents;
-  }
-
   public List<StudentsCourses> selectAllStudentsCourseList() {
     return repository.searchStudentsCourseList();
-  }
-
-  public List<StudentsCourses> searchStudentsCourseList() {
-    List<StudentsCourses> allStudentsCourses = repository.searchStudentsCourseList();
-
-    List<StudentsCourses> filteredStudentsCourses = allStudentsCourses.stream()
-        .filter(courses -> courses.getCourseName().equals("Java"))
-        .collect(Collectors.toList());
-
-    return filteredStudentsCourses;
-
   }
 
   @Transactional//サービス層の登録・更新・削除をするメソッドに必ずつける

--- a/src/main/java/reisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/reisetech/StudentManagement/service/StudentService.java
@@ -70,4 +70,17 @@ public class StudentService {
       repository.registerCourse(course);
     }
   }
+
+  @Transactional
+  public StudentDetail searchStudentDetail(String studentId) {
+    StudentDetail studentDetail = new StudentDetail();
+
+    Student student = repository.searchStudentByStudentId(studentId);
+    List<StudentsCourses> courses = repository.searchCoursesByStudentId(studentId);
+
+    studentDetail.setStudent(student);
+    studentDetail.setStudentsCourses(courses);
+
+    return studentDetail;
+  }
 }

--- a/src/main/java/reisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/reisetech/StudentManagement/service/StudentService.java
@@ -61,7 +61,7 @@ public class StudentService {
   @Transactional
   public void registerCourse(StudentDetail studentDetail) {
     List<StudentsCourses> courses = studentDetail.getStudentsCourses();
-    String studentId = studentDetail.getStudent().getStudentId();
+    int studentId = studentDetail.getStudent().getStudentId();
     LocalDate today = LocalDate.now();
     for (StudentsCourses course : courses) {
       course.setStudentId(studentId);
@@ -83,4 +83,18 @@ public class StudentService {
 
     return studentDetail;
   }
+
+  @Transactional
+  public void updateStudent(StudentDetail studentDetail) {
+    repository.updateStudent(studentDetail.getStudent());
+  }
+
+  @Transactional
+  public void updateCourses(StudentDetail studentDetail) {
+    List<StudentsCourses> courses = studentDetail.getStudentsCourses();
+    for (StudentsCourses course : courses) {
+      repository.updateCourse(course);
+    }
+  }
+
 }

--- a/src/main/resources/templates/activateStudent.html
+++ b/src/main/resources/templates/activateStudent.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>退会者ステータス変更</title>
+</head>
+<body>
+<h1>退会者ステータス変更</h1>
+
+<form th:action="@{/activateStudent}" th:object="${student}" method="post">
+  <div>
+    <input type="hidden" th:field="*{studentId}"/>
+  </div>
+  <div>
+    <p>フルネーム　　：　[[${student.fullname}]]</p>
+    <p>ふりがな　　　：　[[${student.kanaName}]]</p>
+    <p>ニックネーム　：　[[${student.nickname}]]</p>
+    <p>Emailアドレス：　[[${student.email}]]</p>
+    <p>地域　　　　　：　[[${student.city}]]</p>
+    <p>電話番号　　　：　[[${student.telephone}]]</p>
+    <p>年齢　　　　　：　[[${student.age}]]</p>
+    <p>性別：　[[${student.gender}]]</p>
+  </div>
+  <div>
+    <label for="isDeleted_false">ステータス</label>
+    <input type="radio" id="isDeleted_false" name="isDeleted" value="0"
+           th:field="*{isDeleted}"/>在籍
+    <label for="isDeleted_true"></label>
+    <input type="radio" id="isDeleted_true" name="isDeleted" value="1"
+           th:field="*{isDeleted}"/>退会済み
+  </div>
+    <button type="submit">更新</button>
+  </div>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/deletedStudentList.html
+++ b/src/main/resources/templates/deletedStudentList.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>退会者リスト</title>
+</head>
+<body>
+<h3>退会者リスト</h3>
+  <table border="1">
+    <thead>
+    <tr>
+      <th>受講生ID</th>
+      <th>名前</th>
+      <th>ふりがな</th>
+      <th>ニックネーム</th>
+      <th>メールアドレス</th>
+      <th>地域</th>
+      <th>電話番号</th>
+      <th>年齢</th>
+      <th>性別</th>
+      <th>備考</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="student : ${studentList}">
+      <td th:text="${student.studentId}">202407-00001</td>
+      <td>
+        <a th:href="@{/deletedStudent/{studentId}(studentId=${student.studentId})}"
+           th:text="${student.fullname}">服部次郎</a>
+      </td>
+      <td th:text="${student.kanaName}">はっとりじろう</td>
+      <td th:text="${student.nickname}">ハットリくん</td>
+      <td th:text="${student.email}">ninja@gamil.com</td>
+      <td th:text="${student.city}">滋賀県甲賀市</td>
+      <td th:text="${student.telephone}">090-1234-5678</td>
+      <td th:text="${student.age}">33</td>
+      <td th:text="${student.gender}">その他</td>
+      <td th:text="${student.remark}">特になし</td>
+    </tr>
+    </tbody>
+  </table>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/studentAndCourseList.html
+++ b/src/main/resources/templates/studentAndCourseList.html
@@ -23,7 +23,10 @@
   <tbody>
   <tr th:each="student : ${studentList}">
     <td th:text="${student.studentId}">202407-00001</td>
-    <td th:text="${student.fullname}">服部次郎</td>
+    <td>
+      <a th:href="@{/displayStudent/{studentId}(studentId=${student.studentId})}"
+         th:text="${student.fullname}">服部次郎</a>
+    </td>
     <td th:text="${student.kanaName}">はっとりじろう</td>
     <td th:text="${student.nickname}">ハットリくん</td>
     <td th:text="${student.email}">ninja@gamil.com</td>

--- a/src/main/resources/templates/studentAndCourseList.html
+++ b/src/main/resources/templates/studentAndCourseList.html
@@ -24,7 +24,7 @@
   <tr th:each="student : ${studentList}">
     <td th:text="${student.studentId}">202407-00001</td>
     <td>
-      <a th:href="@{/displayStudent/{studentId}(studentId=${student.studentId})}"
+      <a th:href="@{/student/{studentId}(studentId=${student.studentId})}"
          th:text="${student.fullname}">服部次郎</a>
     </td>
     <td th:text="${student.kanaName}">はっとりじろう</td>

--- a/src/main/resources/templates/studentAndCourseList.html
+++ b/src/main/resources/templates/studentAndCourseList.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <title>受講生&コース一覧</title>
+  <title>在籍受講生&コース一覧</title>
 </head>
 <body>
-<h3>受講生一覧</h3>
+<h3>在籍受講生一覧</h3>
 <table border="1">
   <thead>
   <tr>
@@ -41,7 +41,7 @@
 
 <br> <!-- 空行 -->
 
-<h3>コース一覧</h3>
+<h3>在籍受講生のコース一覧</h3>
 <table border="1">
   <thead>
   <tr>

--- a/src/main/resources/templates/studentAndCourseList.html
+++ b/src/main/resources/templates/studentAndCourseList.html
@@ -38,7 +38,10 @@
   </tr>
   </tbody>
 </table>
-
+<div>
+  <button type="button" onclick="window.location.href='/deletedStudentList'">退会者リスト
+  </button>
+</div>
 <br> <!-- 空行 -->
 
 <h3>在籍受講生のコース一覧</h3>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -55,13 +55,12 @@
   </div>
   <div>
     <label for="isDeleted_false">ステータス</label>
-    <input type="radio" id="isDeleted_false" name="isDeleted" value=0
+    <input type="radio" id="isDeleted_false" name="isDeleted" value="0"
            th:field="*{student.isDeleted}"/>在籍
     <label for="isDeleted_true"></label>
-    <input type="radio" id="isDeleted_true" name="isDeleted" value=1
+    <input type="radio" id="isDeleted_true" name="isDeleted" value="1"
            th:field="*{student.isDeleted}"/>退会済み
   </div>
-
   <h2>受講生のコース情報</h2>
 
   <div th:each="course, iterStat : ${studentDetail.studentsCourses}">
@@ -105,32 +104,5 @@
     </button>
   </div>
 </form>
-
-<h2>受講生のコース追加登録</h2>
-
-<form th:action="@{/addCourse}" th:object="${additionalCourse}" method="post">
-  <div>
-    <input type="hidden" th:field="*{studentId}"/>
-  </div>
-  <div>
-    <label for="additionalCourseName">受講コース名</label>
-    <select id="additionalCourseName" th:field="*{courseName}" required>
-      <option value="" disabled selected>選択してください</option>
-      <option value="Java">Java</option>
-      <option value="AWS">AWS</option>
-      <option value="デザイン">デザイン</option>
-      <option value="Webマーケ">Webマーケ</option>
-      <option value="WordPress">WordPress</option>
-    </select>
-  </div>
-  <div>
-    <label for="additionalCourseStartAt">開始日</label>
-    <input type="date" id="additionalCourseStartAt" th:field="*{courseStartAt}" required/>
-  </div>
-  <div>
-    <button type="submit">追加</button>
-  </div>
-</form>
-
 </body>
 </html>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -48,6 +48,12 @@
     <label for="remark">備考</label>
     <input type="text" id="remark" th:field="*{student.remark}">
   </div>
+  <div>
+    <label for="isDeleted_false">ステータス</label>
+    <input type="radio" id="isDeleted_false" name="isDeleted" value=0 th:field="*{student.isDeleted}"/>在籍
+    <label for="isDeleted_true"></label>
+    <input type="radio" id="isDeleted_true" name="isDeleted" value=1 th:field="*{student.isDeleted}"/>退会済み
+  </div>
   <div th:each="course, stat : *{studentsCourses}">
     <label for="courseName"
            th:for="studentsCourses.__${stat.index}__.courseName">受講コース名</label>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -29,7 +29,8 @@
   </div>
   <div>
     <label for="telephone">電話番号</label>
-    <input type="tel" pattern="\d{2,4}-\d{2,4}-\d{4}" placeholder="例: 03-1234-5678" id="telephone" th:field="*{student.telephone}"/>
+    <input type="tel" pattern="\d{2,4}-\d{2,4}-\d{4}" placeholder="例: 03-1234-5678" id="telephone"
+           th:field="*{student.telephone}"/>
   </div>
   <div>
     <label for="age">年齢</label>
@@ -50,23 +51,33 @@
   </div>
   <div>
     <label for="isDeleted_false">ステータス</label>
-    <input type="radio" id="isDeleted_false" name="isDeleted" value=0 th:field="*{student.isDeleted}"/>在籍
+    <input type="radio" id="isDeleted_false" name="isDeleted" value=0
+           th:field="*{student.isDeleted}"/>在籍
     <label for="isDeleted_true"></label>
-    <input type="radio" id="isDeleted_true" name="isDeleted" value=1 th:field="*{student.isDeleted}"/>退会済み
+    <input type="radio" id="isDeleted_true" name="isDeleted" value=1
+           th:field="*{student.isDeleted}"/>退会済み
   </div>
-  <div th:each="course, stat : *{studentsCourses}">
-    <label for="courseName"
-           th:for="studentsCourses.__${stat.index}__.courseName">受講コース名</label>
-    <select id="courseName"
-            th:id="studentsCourses.__${stat.index}__.courseName"
-            th:field="*{studentsCourses[__${stat.index}__].courseName}" required/>
-    <option value="" disabled selected>選択してください</option>
-    <option value="Java">Java</option>
-    <option value="AWS">AWS</option>
-    <option value="デザイン">デザイン</option>
-    <option value="Webマーケ">Webマーケ</option>
-    <option value="WordPress">WordPress</option>
-    </select>
+
+  <h2>受講生のコース情報</h2>
+
+  <div th:each="course, iterStat : ${studentDetail.studentsCourses}">
+    <h3>コース [[${iterStat.index + 1}]]</h3>
+
+    <div>
+      <label for="courseName">コース名</label>
+      <input type="text" id="courseName"
+             th:field="*{studentsCourses[__${iterStat.index}__].courseName}" required/>
+    </div>
+    <div>
+      <label for="courseStartAt">開始日</label>
+      <input type="text" id="courseStartAt"
+             th:field="*{studentsCourses[__${iterStat.index}__].courseStartAt}" required/>
+    </div>
+    <div>
+      <label for="courseEndAt">終了日</label>
+      <input type="text" id="courseEndAt"
+             th:field="*{studentsCourses[__${iterStat.index}__].courseEndAt}"/>
+    </div>
   </div>
   <div>
     <button type="submit">更新</button>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>受講生更新</title>
+</head>
+<body>
+<h1>受講生更新</h1>
+
+<form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="fullname">フルネーム</label>
+    <input type="text" maxlength="20" id="fullname" th:field="*{student.fullname}" required/>
+  </div>
+  <div>
+    <label for="kanaName">ふりがな</label>
+    <input type="text" maxlength="20" id="kanaName" th:field="*{student.kanaName}" required/>
+  </div>
+  <div>
+    <label for="nickname">ニックネーム</label>
+    <input type="text" maxlength="20" id="nickname" th:field="*{student.nickname}"/>
+  </div>
+  <div>
+    <label for="email">Emailアドレス</label>
+    <input type="email" id="email" th:field="*{student.email}" required/>
+  </div>
+  <div>
+    <label for="city">地域</label>
+    <input type="text" maxlength="15" id="city" th:field="*{student.city}"/>
+  </div>
+  <div>
+    <label for="telephone">電話番号</label>
+    <input type="tel" pattern="\d{2,4}-\d{2,4}-\d{4}" placeholder="例: 03-1234-5678" id="telephone" th:field="*{student.telephone}"/>
+  </div>
+  <div>
+    <label for="age">年齢</label>
+    <input type="number" min="12" max="150" id="age" th:field="*{student.age}"/>
+  </div>
+  <div>
+    <label for="gender_male">性別</label>
+    <input type="radio" id="gender_male" name="gender" value="男" th:field="*{student.gender}"/>男
+    <label for="gender_female"></label>
+    <input type="radio" id="gender_female" name="gender" value="女" th:field="*{student.gender}"/>女
+    <label for="gender_other"></label>
+    <input type="radio" id="gender_other" name="gender" value="その他"
+           th:field="*{student.gender}"/>その他
+  </div>
+  <div>
+    <label for="remark">備考</label>
+    <input type="text" id="remark" th:field="*{student.remark}">
+  </div>
+  <div th:each="course, stat : *{studentsCourses}">
+    <label for="courseName"
+           th:for="studentsCourses.__${stat.index}__.courseName">受講コース名</label>
+    <select id="courseName"
+            th:id="studentsCourses.__${stat.index}__.courseName"
+            th:field="*{studentsCourses[__${stat.index}__].courseName}" required/>
+    <option value="" disabled selected>選択してください</option>
+    <option value="Java">Java</option>
+    <option value="AWS">AWS</option>
+    <option value="デザイン">デザイン</option>
+    <option value="Webマーケ">Webマーケ</option>
+    <option value="WordPress">WordPress</option>
+    </select>
+  </div>
+  <div>
+    <button type="submit">更新</button>
+  </div>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -61,6 +61,7 @@
     <input type="radio" id="isDeleted_true" name="isDeleted" value="1"
            th:field="*{student.isDeleted}"/>退会済み
   </div>
+
   <h2>受講生のコース情報</h2>
 
   <div th:each="course, iterStat : ${studentDetail.studentsCourses}">
@@ -104,5 +105,32 @@
     </button>
   </div>
 </form>
+
+<h2>受講生のコース追加登録</h2>
+
+<form th:action="@{/addCourse}" th:object="${additionalCourse}" method="post">
+  <div>
+    <input type="hidden" th:field="*{studentId}"/>
+  </div>
+  <div>
+    <label for="additionalCourseName">受講コース名</label>
+    <select id="additionalCourseName" th:field="*{courseName}" required>
+      <option value="" disabled selected>選択してください</option>
+      <option value="Java">Java</option>
+      <option value="AWS">AWS</option>
+      <option value="デザイン">デザイン</option>
+      <option value="Webマーケ">Webマーケ</option>
+      <option value="WordPress">WordPress</option>
+    </select>
+  </div>
+  <div>
+    <label for="additionalCourseStartAt">開始日</label>
+    <input type="date" id="additionalCourseStartAt" th:field="*{courseStartAt}" required/>
+  </div>
+  <div>
+    <button type="submit">追加</button>
+  </div>
+</form>
+
 </body>
 </html>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -5,8 +5,12 @@
 </head>
 <body>
 <h1>受講生更新</h1>
+<h2>受講生プロフィール更新</h2>
 
 <form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <input type="hidden" th:field="*{student.studentId}"/>
+  </div>
   <div>
     <label for="fullname">フルネーム</label>
     <input type="text" maxlength="20" id="fullname" th:field="*{student.fullname}" required/>
@@ -64,10 +68,26 @@
     <h3>コース [[${iterStat.index + 1}]]</h3>
 
     <div>
-      <label for="courseName">コース名</label>
-      <input type="text" id="courseName"
-             th:field="*{studentsCourses[__${iterStat.index}__].courseName}" required/>
+      <input type="hidden" th:field="*{studentsCourses[__${iterStat.index}__].courseId}"/>
     </div>
+    <div>
+      <input type="hidden" th:field="*{studentsCourses[__${iterStat.index}__].studentId}"/>
+    </div>
+
+    <div>
+      <label for="courseName">受講コース名</label>
+      <select id="courseName" th:field="*{studentsCourses[__${iterStat.index}__].courseName}"
+              required>
+        <option value="Java" th:selected="${course.courseName == 'Java'}">Java</option>
+        <option value="AWS" th:selected="${course.courseName == 'AWS'}">AWS</option>
+        <option value="デザイン" th:selected="${course.courseName == 'デザイン'}">デザイン</option>
+        <option value="Webマーケ" th:selected="${course.courseName == 'Webマーケ'}">Webマーケ
+        </option>
+        <option value="WordPress" th:selected="${course.courseName == 'WordPress'}">WordPress
+        </option>
+      </select>
+    </div>
+
     <div>
       <label for="courseStartAt">開始日</label>
       <input type="text" id="courseStartAt"
@@ -81,6 +101,8 @@
   </div>
   <div>
     <button type="submit">更新</button>
+    <button type="button" onclick="window.location.href='/allStudentAndCourseList'">キャンセル
+    </button>
   </div>
 </form>
 

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <title>受講生更新</title>
+  <title>受講生詳細</title>
 </head>
 <body>
-<h1>受講生更新</h1>
+<h1>受講生詳細</h1>
 <h2>受講生プロフィール更新</h2>
 
 <form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
@@ -89,8 +89,8 @@
     </div>
 
     <div>
-      <label for="courseStartAt">開始日</label>
-      <input type="text" id="courseStartAt"
+      <p>開始日　[[${course.courseStartAt}]]</p>
+      <input type="hidden"
              th:field="*{studentsCourses[__${iterStat.index}__].courseStartAt}" required/>
     </div>
     <div>
@@ -103,6 +103,32 @@
     <button type="submit">更新</button>
     <button type="button" onclick="window.location.href='/allStudentAndCourseList'">キャンセル
     </button>
+  </div>
+</form>
+
+<h2>受講生のコース追加登録</h2>
+
+<form th:action="@{/addCourse}" th:object="${additionalCourse}" method="post">
+  <div>
+    <input type="hidden" th:field="*{studentId}"/>
+  </div>
+  <div>
+    <label for="additionalCourseName">受講コース名</label>
+    <select id="additionalCourseName" th:field="*{courseName}" required>
+      <option value="" disabled selected>選択してください</option>
+      <option value="Java">Java</option>
+      <option value="AWS">AWS</option>
+      <option value="デザイン">デザイン</option>
+      <option value="Webマーケ">Webマーケ</option>
+      <option value="WordPress">WordPress</option>
+    </select>
+  </div>
+  <div>
+    <label for="additionalCourseStartAt">開始日</label>
+    <input type="date" id="additionalCourseStartAt" th:field="*{courseStartAt}" required/>
+  </div>
+  <div>
+    <button type="submit">追加</button>
   </div>
 </form>
 


### PR DESCRIPTION
## 実装内容

### 1.Webブラウザ上に受講生情報更新フォームを作成し、データベースに対して更新処理を行うことができる処理を実装
受講生プロフィールの各項目および受講中のコース名とその受講終了日を更新できる。また、受講コースを追加することができる。
更新フォームを持つページには、在籍受講生一覧の名前をクリックすることで遷移することができる。
![image](https://github.com/user-attachments/assets/ee7f5fc6-78cb-477c-a99b-09ff8d5e4c80)
![image](https://github.com/user-attachments/assets/4ecbccf3-860e-493a-b1b6-5bb91b17acca)

項目を修正し、「更新」ボタンを押すと、在籍受講生一覧に遷移し、結果が反映されていることを確認できる。
![image](https://github.com/user-attachments/assets/584481d7-717a-49db-9dd2-f9fda7e591bf)
![image](https://github.com/user-attachments/assets/5836ca1b-74de-4569-84e2-2fc8a5072e11)

コース名と開始日を選択して「追加」ボタンを押すと、コースを追加登録することができる。ボタンを押すと、在籍受講生一覧に遷移し、結果が反映されていることを確認できる。
![image](https://github.com/user-attachments/assets/0d931964-6df2-4aed-a51e-723d07077fd7)
![image](https://github.com/user-attachments/assets/cb53dc53-e741-43ec-9eb1-28ca4f8a71a1)

### 2.受講生情報更新フォームから、受講生のステータスを変更し、論理削除を行う処理を実装
プロフィール情報のステータスで「退会済み」を選択することで、論理削除を行う。「更新」を押すと在籍受講生一覧に遷移し、論理削除された受講生は表示されなくなる。
![image](https://github.com/user-attachments/assets/ad2d2ebd-246e-4540-8c76-b74c07d2f0f8)
![image](https://github.com/user-attachments/assets/11897b2e-c88f-497d-8c09-6241e8794894)



