### PR TITLE
[課題41] WebMvcテストとバリデーションのテスト

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat-runtime'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	mockitoAgent "net.bytebuddy:byte-buddy-agent:1.17.8"

--- a/build.gradle
+++ b/build.gradle
@@ -61,4 +61,25 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 	jvmArgs "-javaagent:${configurations.mockitoAgent.singleFile.absolutePath}"
+
+	testLogging {
+		events "passed", "failed", "skipped"
+		exceptionFormat "full"
+		showExceptions true
+		showCauses true
+		showStackTraces true
+	}
+
+	afterSuite { desc, result ->
+		if (!desc.parent) {
+			println ""
+			println "========== Test Summary =========="
+			println "Result   : ${result.resultType}"
+			println "Total    : ${result.testCount}"
+			println "Passed   : ${result.successfulTestCount}"
+			println "Failed   : ${result.failedTestCount}"
+			println "Skipped  : ${result.skippedTestCount}"
+			println "=================================="
+		}
+	}
 }

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -31,7 +31,7 @@ class StudentControllerTest {
   private ErrorDetailsBuilder errorDetailsBuilder;
 
   @Test
-  void アクティブ受講生一覧検索_サービスの処理が呼び出せていること() throws Exception {
+  void アクティブ受講生一覧検索_リクエスト時に200OKが返りサービスが呼び出されること() throws Exception {
     // Act
     mockMvc.perform(MockMvcRequestBuilders.get("/students"))
         .andExpect(status().isOk());
@@ -41,7 +41,7 @@ class StudentControllerTest {
   }
 
   @Test
-  void 受講生詳細単一検索成功_サービスの処理が呼び出せていること()
+  void 受講生詳細単一検索成功_存在するstudentIdを指定すると200OKが返りサービスが呼び出されること()
       throws Exception {
     // Arrange
     Integer studentId = 1;
@@ -71,7 +71,7 @@ class StudentControllerTest {
   }
 
   @Test
-  void 受講生詳細単一検索失敗_studentIdに数値以外を渡すと400エラーが返されること()
+  void 受講生詳細単一検索失敗_studentIdに数値以外を渡すと400エラーが返されサービスが呼び出されないこと()
       throws Exception {
     // Arrange
     String studentId = "test";
@@ -79,16 +79,17 @@ class StudentControllerTest {
     // Act & Assert
     mockMvc.perform(MockMvcRequestBuilders.get("/students/" + studentId)) // 文字列を渡す
         .andExpect(status().isBadRequest()); // 400 BAD_REQUESTが返ること
+    Mockito.verify(service, times(0)).searchStudentDetail(Mockito.anyInt());
   }
 
   @Test
-  void 受講生詳細単一検索失敗_studentIdに0以下の数値を渡すと400エラーが返されること()
+  void 受講生詳細単一検索失敗_studentIdに0以下の数値を渡すと400エラーが返されサービスが呼び出されないこと()
       throws Exception {
     int notPositiveStudentId = 0;
 
     mockMvc.perform(MockMvcRequestBuilders.get("/students/" + notPositiveStudentId))
         .andExpect(status().isBadRequest());
-
+    Mockito.verify(service, times(0)).searchStudentDetail(Mockito.anyInt());
   }
 
   @Test void 受講生詳細登録成功_妥当なJSONリクエストで200OKが返りサービスが呼び出されること() throws Exception {

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -180,7 +180,7 @@ class StudentControllerTest {
     Integer courseId = 99;
 
     StudentDetail studentDetail = TestDataFactory.makeCompletedStudentDetail(studentId, courseId);
-    Mockito.when(service.updateStudentDetail(studentDetail))
+    Mockito.when(service.updateStudentDetail(Mockito.any(StudentDetail.class)))
         .thenThrow(new TargetNotFoundException("Student.studentId","更新対象のインスタンスが見つかりませんでした"));
 
     // Act & Assert

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -89,7 +89,7 @@ class StudentControllerTest {
   }
 
   @Test
-  void 受講生詳細単一検索失敗_studentIdに0以下の数値を渡すと渡すと400エラーが返されること()
+  void 受講生詳細単一検索失敗_studentIdに0以下の数値を渡すと400エラーが返されること()
       throws Exception {
     int notPositiveStudentId = 0;
 
@@ -123,6 +123,19 @@ class StudentControllerTest {
   }
 
   @Test
+  void 受講生詳細登録失敗_不正なリクエストボディを受け取ると400エラーが返されること()
+      throws Exception {
+    // Arrange
+    StudentDetail inValidRequest = new StudentDetail();
+
+    // Act & Assert
+    mockMvc.perform(MockMvcRequestBuilders.post("/students")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(inValidRequest)))
+        .andExpect(status().isBadRequest()); // 400 BAD_REQUESTが返ること
+  }
+
+  @Test
   void 受講生詳細更新成功_サービスにリクエストボディが正しく渡されていること()
       throws Exception {
     // Arrange
@@ -144,6 +157,37 @@ class StudentControllerTest {
     assertThat(captor.getValue())
         .usingRecursiveComparison()
         .isEqualTo(studentDetail);
+  }
+
+  @Test
+  void 受講生詳細更新失敗_不正なリクエストボディを受け取ると400エラーが返されること()
+      throws Exception {
+    // Arrange
+    StudentDetail inValidRequest = new StudentDetail();
+
+    // Act & Assert
+    mockMvc.perform(MockMvcRequestBuilders.put("/students")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(inValidRequest)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void 受講生詳細更新失敗_サービスから例外を受け取り404エラーを返していること()
+      throws Exception {
+    // Arrange
+    Integer studentId = 99;
+    Integer courseId = 99;
+
+    StudentDetail studentDetail = TestDataFactory.makeCompletedStudentDetail(studentId, courseId);
+    Mockito.when(service.updateStudentDetail(studentDetail))
+        .thenThrow(new TargetNotFoundException("Student.studentId","更新対象のインスタンスが見つかりませんでした"));
+
+    // Act & Assert
+    mockMvc.perform(MockMvcRequestBuilders.put("/students")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(studentDetail))
+    ).andExpect(status().isNotFound());
   }
 
 }

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -1,13 +1,10 @@
 package raisetech.student.management.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -32,10 +29,6 @@ class StudentControllerTest {
 
   @MockitoBean
   private ErrorDetailsBuilder errorDetailsBuilder;
-
-  private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-
-  ArgumentCaptor<StudentDetail> captor = ArgumentCaptor.forClass(StudentDetail.class);
 
   @Test
   void アクティブ受講生一覧検索_サービスの処理が呼び出せていること() throws Exception {
@@ -98,96 +91,166 @@ class StudentControllerTest {
 
   }
 
+  @Test void 受講生詳細登録成功_妥当なJSONリクエストで200OKが返りサービスが呼び出されること() throws Exception {
+    // Act
+    mockMvc.perform(MockMvcRequestBuilders.post("/students")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(
+            """
+            {
+                "student": {
+                    "fullName": "山田太郎",
+                    "kanaName": "やまだたろう",
+                    "nickname": "タロー",
+                    "email": "taro@email.com",
+                    "area": "東京都練馬区",
+                    "telephone": "090-0000-0000",
+                    "age": 20,
+                    "sex": "男",
+                    "remark": "特になし"
+                },
+                "studentCourses": [
+                    {
+                         "courseName": "Javaコース"
+                    }
+                ]
+            }
+            
+            """
+        ))
+        .andExpect(status().isOk());
+    // Assert
+    Mockito.verify(service, times(1)).registerStudentDetail(any());
+  }
+
   @Test
-  void 受講生詳細登録成功_サービスにリクエストボディが正しく渡されていること()
+  void 受講生詳細登録失敗_不正なJSONリクエストを受け取ると400エラーが返されサービスが呼び出されないこと()
       throws Exception {
-    // Arrange
-    Integer studentId = 1;
-    Integer courseId = 1;
-
-    StudentDetail studentDetail = TestDataFactory.makeCompletedStudentDetail(studentId, courseId);
-    Mockito.when(service.registerStudentDetail(Mockito.any(StudentDetail.class)))
-        .thenReturn(studentDetail);
-
     // Act
     mockMvc.perform(MockMvcRequestBuilders.post("/students")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(studentDetail)))
+            .content(
+                """
+                {
+                    "student": {},
+                    "studentCourses": []
+                }
+                """
+            ))
+        .andExpect(status().isBadRequest());
+
+    // Assert
+    Mockito.verify(service, times(0)).registerStudentDetail(any(StudentDetail.class));
+  }
+
+  @Test
+  void 受講生詳細更新成功_妥当なJSONリクエストで200OKが返りサービスが呼び出されること()
+      throws Exception {
+    // Arrange
+    Mockito.when(service.updateStudentDetail(any(StudentDetail.class)))
+        .thenReturn(TestDataFactory.makeCompletedStudentDetail(1, 1));
+
+    // Act
+    mockMvc.perform(MockMvcRequestBuilders.put("/students")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                    "student": {
+                        "studentId": 1,
+                        "fullName": "山田太郎",
+                        "kanaName": "やまだたろう",
+                        "nickname": "タロー",
+                        "email": "taro@email.com",
+                        "area": "東京都練馬区",
+                        "telephone": "090-0000-0000",
+                        "age": 20,
+                        "sex": "男",
+                        "remark": "特になし",
+                        "isDeleted": false
+                    },
+                    "studentCourses": [
+                        {
+                            "courseId": 1,
+                            "studentId": 1,
+                            "courseName": "Javaコース",
+                            "courseStartAt": "2025-04-01",
+                            "courseEndAt": "2025-10-01",
+                            "deleted": false
+                        }
+                    ]
+                }
+                """
+            ))
         .andExpect(status().isOk());
 
     // Assert
-    Mockito.verify(service, times(1)).registerStudentDetail(captor.capture());
-    assertThat(captor.getValue())
-        .usingRecursiveComparison()
-        .isEqualTo(studentDetail);
+    Mockito.verify(service, times(1)).updateStudentDetail(any(StudentDetail.class));
   }
 
   @Test
-  void 受講生詳細登録失敗_不正なリクエストボディを受け取ると400エラーが返されること()
+  void 受講生詳細更新失敗_不正なJSONリクエストを受け取ると400エラーが返されサービスが呼び出されないこと()
       throws Exception {
-    // Arrange
-    StudentDetail inValidRequest = new StudentDetail();
-
-    // Act & Assert
-    mockMvc.perform(MockMvcRequestBuilders.post("/students")
+    // Act
+    mockMvc.perform(MockMvcRequestBuilders.put("/students")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(inValidRequest)))
-        .andExpect(status().isBadRequest()); // 400 BAD_REQUESTが返ること
+            .content(
+                """
+                {
+                    "student": {},
+                    "studentCourses": []
+                }
+                """
+            ))
+        .andExpect(status().isBadRequest());
+
+    // Assert
+    Mockito.verify(service, times(0)).updateStudentDetail(any(StudentDetail.class));
   }
 
   @Test
-  void 受講生詳細更新成功_サービスにリクエストボディが正しく渡されていること()
+  void 受講生詳細更新失敗_存在しない受講生を更新しようとすると404エラーが返ること()
       throws Exception {
     // Arrange
-    Integer studentId = 1;
-    Integer courseId = 1;
-
-    StudentDetail studentDetail = TestDataFactory.makeCompletedStudentDetail(studentId, courseId);
-    Mockito.when(service.updateStudentDetail(Mockito.any(StudentDetail.class)))
-        .thenReturn(studentDetail);
+    Mockito.when(service.updateStudentDetail(any(StudentDetail.class)))
+        .thenThrow(new TargetNotFoundException("Student.studentId", "更新対象のインスタンスが見つかりませんでした"));
 
     // Act
     mockMvc.perform(MockMvcRequestBuilders.put("/students")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(studentDetail))
-    ).andExpect(status().isOk());
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                {
+                    "student": {
+                        "studentId": 99,
+                        "fullName": "山田太郎",
+                        "kanaName": "やまだたろう",
+                        "nickname": "タロー",
+                        "email": "taro@email.com",
+                        "area": "東京都練馬区",
+                        "telephone": "090-0000-0000",
+                        "age": 20,
+                        "sex": "男",
+                        "remark": "特になし",
+                        "isDeleted": false
+                    },
+                    "studentCourses": [
+                        {
+                            "courseId": 99,
+                            "studentId": 99,
+                            "courseName": "Javaコース",
+                            "courseStartAt": "2025-04-01",
+                            "courseEndAt": "2025-10-01",
+                            "deleted": false
+                        }
+                    ]
+                }
+                """
+            ))
+        .andExpect(status().isNotFound());
 
     // Assert
-    Mockito.verify(service, times(1)).updateStudentDetail(captor.capture());
-    assertThat(captor.getValue())
-        .usingRecursiveComparison()
-        .isEqualTo(studentDetail);
-  }
-
-  @Test
-  void 受講生詳細更新失敗_不正なリクエストボディを受け取ると400エラーが返されること()
-      throws Exception {
-    // Arrange
-    StudentDetail inValidRequest = new StudentDetail();
-
-    // Act & Assert
-    mockMvc.perform(MockMvcRequestBuilders.put("/students")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(inValidRequest)))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  void 受講生詳細更新失敗_サービスから例外を受け取り404エラーを返していること()
-      throws Exception {
-    // Arrange
-    Integer studentId = 99;
-    Integer courseId = 99;
-
-    StudentDetail studentDetail = TestDataFactory.makeCompletedStudentDetail(studentId, courseId);
-    Mockito.when(service.updateStudentDetail(Mockito.any(StudentDetail.class)))
-        .thenThrow(new TargetNotFoundException("Student.studentId","更新対象のインスタンスが見つかりませんでした"));
-
-    // Act & Assert
-    mockMvc.perform(MockMvcRequestBuilders.put("/students")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(studentDetail))
-    ).andExpect(status().isNotFound());
+    Mockito.verify(service, times(1)).updateStudentDetail(any(StudentDetail.class));
   }
 
 }

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -1,0 +1,149 @@
+package raisetech.student.management.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import raisetech.student.management.data.domain.StudentDetail;
+import raisetech.student.management.exception.TargetNotFoundException;
+import raisetech.student.management.exception.handler.ErrorDetailsBuilder;
+import raisetech.student.management.service.StudentService;
+import raisetech.student.management.testutil.TestDataFactory;
+
+@WebMvcTest(StudentController.class)
+class StudentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private StudentService service;
+
+  @MockitoBean
+  private ErrorDetailsBuilder errorDetailsBuilder;
+
+  private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+  ArgumentCaptor<StudentDetail> captor = ArgumentCaptor.forClass(StudentDetail.class);
+
+  @Test
+  void アクティブ受講生一覧検索_サービスの処理が呼び出せていること() throws Exception {
+    // Act
+    mockMvc.perform(MockMvcRequestBuilders.get("/students"))
+        .andExpect(status().isOk());
+
+    // Assert
+    Mockito.verify(service, times(1)).searchStudentDetailList();
+  }
+
+  @Test
+  void 受講生詳細単一検索成功_サービスの処理が呼び出せていること()
+      throws Exception {
+    // Arrange
+    Integer studentId = 1;
+    Integer courseId = 1;
+    StudentDetail studentDetail = TestDataFactory.makeCompletedStudentDetail(studentId, courseId);
+    Mockito.when(service.searchStudentDetail(studentId)).thenReturn(studentDetail);
+
+    // Act & Assert
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/" + studentId))
+        .andExpect(status().isOk());
+    Mockito.verify(service, times(1)).searchStudentDetail(studentId);
+  }
+
+  @Test
+  void 受講生詳細単一検索失敗_サービスから例外を受け取り404エラーを返していること() throws Exception {
+    // Arrange
+    int studentId = 99;
+    Mockito.when(service.searchStudentDetail(studentId))
+        .thenThrow(new TargetNotFoundException("studentId", "指定したIDの受講生は見つかりませんでした"));
+
+    // Act
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/" + studentId))
+        .andExpect(status().isNotFound());
+
+    // Assert
+    Mockito.verify(service, times(1)).searchStudentDetail(studentId);
+  }
+
+  @Test
+  void 受講生詳細単一検索失敗_studentIdに数値以外を渡すと400エラーが返されること()
+      throws Exception {
+    // Arrange
+    String studentId = "test";
+
+    // Act & Assert
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/" + studentId)) // 文字列を渡す
+        .andExpect(status().isBadRequest()); // 400 BAD_REQUESTが返ること
+  }
+
+  @Test
+  void 受講生詳細単一検索失敗_studentIdに0以下の数値を渡すと渡すと400エラーが返されること()
+      throws Exception {
+    int notPositiveStudentId = 0;
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/" + notPositiveStudentId))
+        .andExpect(status().isBadRequest());
+
+  }
+
+  @Test
+  void 受講生詳細登録成功_サービスにリクエストボディが正しく渡されていること()
+      throws Exception {
+    // Arrange
+    Integer studentId = 1;
+    Integer courseId = 1;
+
+    StudentDetail studentDetail = TestDataFactory.makeCompletedStudentDetail(studentId, courseId);
+    Mockito.when(service.registerStudentDetail(Mockito.any(StudentDetail.class)))
+        .thenReturn(studentDetail);
+
+    // Act
+    mockMvc.perform(MockMvcRequestBuilders.post("/students")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isOk());
+
+    // Assert
+    Mockito.verify(service, times(1)).registerStudentDetail(captor.capture());
+    assertThat(captor.getValue())
+        .usingRecursiveComparison()
+        .isEqualTo(studentDetail);
+  }
+
+  @Test
+  void 受講生詳細更新成功_サービスにリクエストボディが正しく渡されていること()
+      throws Exception {
+    // Arrange
+    Integer studentId = 1;
+    Integer courseId = 1;
+
+    StudentDetail studentDetail = TestDataFactory.makeCompletedStudentDetail(studentId, courseId);
+    Mockito.when(service.updateStudentDetail(Mockito.any(StudentDetail.class)))
+        .thenReturn(studentDetail);
+
+    // Act
+    mockMvc.perform(MockMvcRequestBuilders.put("/students")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(studentDetail))
+    ).andExpect(status().isOk());
+
+    // Assert
+    Mockito.verify(service, times(1)).updateStudentDetail(captor.capture());
+    assertThat(captor.getValue())
+        .usingRecursiveComparison()
+        .isEqualTo(studentDetail);
+  }
+
+}

--- a/src/test/java/raisetech/student/management/data/StudentCourseTest.java
+++ b/src/test/java/raisetech/student/management/data/StudentCourseTest.java
@@ -192,7 +192,7 @@ class StudentCourseTest {
     StudentCourse validStudentCourse = TestDataFactory.makeCompletedStudentCourse(studentId,courseId);
 
     Set<ConstraintViolation<StudentCourse>> violations = validator.validate(validStudentCourse,
-        CreateGroup.class);
+        UpdateGroup.class);
 
     assertThat(violations).isEmpty();
   }

--- a/src/test/java/raisetech/student/management/data/StudentCourseTest.java
+++ b/src/test/java/raisetech/student/management/data/StudentCourseTest.java
@@ -1,0 +1,200 @@
+package raisetech.student.management.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.time.LocalDate;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import raisetech.student.management.testutil.TestDataFactory;
+import raisetech.student.management.validation.CreateGroup;
+import raisetech.student.management.validation.UpdateGroup;
+
+class StudentCourseTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUpValidator() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_フィールド: {0} がnullのとき violation={1}")
+  @CsvSource({// trueはNotNull, falseはnull許容
+      "courseId,false",
+      "studentId,false",
+      "courseName,true",
+      "courseStartAt,false",
+      "courseEndAt,false"
+  })
+  void 登録時_各フィールドのnull許容性のテスト(String fieldName,
+      boolean expectViolation) {
+    // Arrange
+    LocalDate now = LocalDate.now();
+    StudentCourse studentCourse = new StudentCourse(
+        fieldName.equals("courseId") ? null : 1,
+        fieldName.equals("studentId") ? null : 1,
+        fieldName.equals("courseName") ? null : "Javaコース",
+        fieldName.equals("courseStartAt") ? null : now,
+        fieldName.equals("courseEndAt") ? null : now.plusMonths(6)
+    );
+
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse,
+        CreateGroup.class);
+
+    // Act & Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals(fieldName))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時 courseNameが{0}文字のとき violation={1}")
+  @CsvSource({
+      "9,false",
+      "10,false",
+      "11,true"
+  })
+  void 登録時_コース名の文字数の境界値テスト(int size, boolean expectViolation)throws Exception{
+    // Arrange
+    Integer studentId = null;
+    Integer courseId = null;
+    String over10char = "あ".repeat(size);
+    LocalDate now = LocalDate.now();
+    StudentCourse studentCourse = new StudentCourse(
+        courseId,
+        studentId,
+        over10char,
+        now,
+        now.plusMonths(6)
+    );
+
+    // Act
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse,
+        CreateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals("courseName"))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+
+  }
+
+  @Test
+  void 登録時_StudentCourseの各のフィールドが妥当な値を持つときバリデーション違反が起きない(){
+    Integer studentId = null;
+    Integer courseId = null;
+    StudentCourse validStudentCourse = TestDataFactory.makeCompletedStudentCourse(studentId,courseId);
+
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(validStudentCourse,
+        CreateGroup.class);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest(name = "[{index}] 更新時_フィールド: {0} がnullのとき violation={1}")
+  @CsvSource({// trueはNotNull, falseはnull許容
+      "courseId,true",
+      "studentId,false",
+      "courseName,true",
+      "courseStartAt,false",
+      "courseEndAt,false"
+  })
+  void 更新時_各フィールドのnull許容性のテスト(String fieldName,
+      boolean expectViolation) {
+    // Arrange
+    LocalDate now = LocalDate.now();
+    StudentCourse studentCourse = new StudentCourse(
+        fieldName.equals("courseId") ? null : 1,
+        fieldName.equals("studentId") ? null : 1,
+        fieldName.equals("courseName") ? null : "Javaコース",
+        fieldName.equals("courseStartAt") ? null : now,
+        fieldName.equals("courseEndAt") ? null : now.plusMonths(6)
+    );
+
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse,
+        UpdateGroup.class);
+
+    // Act & Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals(fieldName))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @Test
+  void 更新時_courseIdが1未満の数値の時バリデーション違反が起きる() {
+    Integer studentId = 1;
+    Integer courseId = -3;
+    StudentCourse invalidStudentCourse = TestDataFactory.makeCompletedStudentCourse(studentId,courseId);
+
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(invalidStudentCourse,
+        UpdateGroup.class);
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream()
+        .anyMatch(v -> v.getPropertyPath().toString().equals("courseId"))).isTrue();
+  }
+
+  @ParameterizedTest(name = "[{index}] 更新時 courseNameが{0}文字のとき violation={1}")
+  @CsvSource({
+      "9,false",
+      "10,false",
+      "11,true"
+  })
+  void 更新時_コース名の文字数の境界値テスト(int size, boolean expectViolation)throws Exception{
+    // Arrange
+    Integer studentId = 1;
+    Integer courseId = 1;
+    String over10char = "あ".repeat(size);
+    LocalDate now = LocalDate.now();
+    StudentCourse studentCourse = new StudentCourse(
+        courseId,
+        studentId,
+        over10char,
+        now,
+        now.plusMonths(6)
+    );
+
+    // Act
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse,
+        UpdateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals("courseName"))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+
+  }
+
+  @Test
+  void 更新時_StudentCourseの各のフィールドが妥当な値を持つときバリデーション違反が起きない(){
+    Integer studentId = null;
+    Integer courseId = 1;
+    StudentCourse validStudentCourse = TestDataFactory.makeCompletedStudentCourse(studentId,courseId);
+
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(validStudentCourse,
+        CreateGroup.class);
+
+    assertThat(violations).isEmpty();
+  }
+
+}

--- a/src/test/java/raisetech/student/management/data/StudentTest.java
+++ b/src/test/java/raisetech/student/management/data/StudentTest.java
@@ -1,0 +1,609 @@
+package raisetech.student.management.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import raisetech.student.management.testutil.TestDataFactory;
+import raisetech.student.management.validation.CreateGroup;
+import raisetech.student.management.validation.UpdateGroup;
+
+class StudentTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUpValidator() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_フィールド: {0} がnullのとき violation={1}")
+  @CsvSource({// trueはNotNull, falseはnull許容
+      "studentId,false",
+      "fullName,true",
+      "kanaName,true",
+      "nickname,true",
+      "email,true",
+      "area,false",
+      "telephone,false",
+      "age,false",
+      "sex,false",
+      "remark,false"
+  })
+  void 登録時_各フィールドのnull許容性のテスト(String fieldName,
+      boolean expectViolation) {
+    // Arrange
+    Student student = new Student(
+        fieldName.equals("studentId") ? null : 1,
+        fieldName.equals("fullName") ? null : "山田太郎",
+        fieldName.equals("kanaName") ? null : "やまだたろう",
+        fieldName.equals("nickname") ? null : "タロー",
+        fieldName.equals("email") ? null : "yamada@example.com",
+        fieldName.equals("area") ? null : "東京都",
+        fieldName.equals("telephone") ? null : "090-0000-0000",
+        fieldName.equals("age") ? null : 20,
+        fieldName.equals("sex") ? null : "男",
+        fieldName.equals("remark") ? null : "特になし",
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(student,
+        CreateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals(fieldName))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_フィールド：{0}が上限50文字に対して{1}文字のとき violation={2}")
+  @CsvSource({
+      "fullName,49,false",
+      "fullName,50,false",
+      "fullName,51,true",
+
+      "kanaName,49,false",
+      "kanaName,50,false",
+      "kanaName,51,true",
+
+      "nickname,49,false",
+      "nickname,50,false",
+      "nickname,51,true",
+
+      "area,49,false",
+      "area,50,false",
+      "area,51,true",
+  })
+  void 登録時_50文字上限のフィールドの文字数の境界値テスト(String fieldName, int length, boolean expectViolation) throws Exception {
+    // Arrange
+    Integer studentId = null;
+    String testValue = "あ".repeat(length);
+    Student invalidStudent = new Student(
+        studentId,
+        fieldName.equals("fullName") ? testValue : "山田太郎",
+        fieldName.equals("kanaName") ? testValue : "やまだたろう",
+        fieldName.equals("nickname") ? testValue : "タロー",
+        "test@example.com",
+        fieldName.equals("area") ? testValue : "東京都",
+        "090-0000-0000",
+        20,
+        "男",
+        "特になし",
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        CreateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations)
+          .anyMatch(v -> v.getPropertyPath().toString().equals(fieldName));
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_フィールド：remark が上限200文字に対して{0}文字のとき violation={1}")
+  @CsvSource({
+      "199,false",
+      "200,false",
+      "201,true"
+  })
+  void 登録時_200文字上限のフィールドの文字数の境界値テスト(int length, boolean expectViolation) throws Exception {
+    // Arrange
+    Integer studentId = null;
+    String testValue = "あ".repeat(length);
+    Student invalidStudent = new Student(
+        studentId,
+        "山田太郎",
+        "やまだたろう",
+        "タロー",
+        "test@example.com",
+        "東京都",
+        "090-0000-0000",
+        20,
+        "男",
+        testValue,
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        CreateGroup.class);
+
+    // Assert
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations)
+          .anyMatch(v -> v.getPropertyPath().toString().equals("remark"));
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_emailの形式が {0} のときバリデーション違反が起きる")
+  @ValueSource(strings = {
+      "plainaddress",        // @なし
+      "@missingusername.com",// ユーザー名なし
+      "username@.com",       // ドメイン名先頭にドット
+      "user@com.",           // ドメイン末尾にドット
+      "user@-com.com",       // 不正なドメイン記号
+      "user@com..com"        // ドット連続
+  })
+  void 登録時_emailの形式が不正なときバリデーション違反が起きる(String invalidEmail) {
+    // Arrange
+    Integer studentId = null;
+    Student invalidStudent = new Student(
+        studentId, "山田太郎", "やまだたろう", "タロー", invalidEmail,
+        "東京都", "090-0000-0000", 20, "男", "", false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        CreateGroup.class);
+
+    // Assert
+    assertThat(violations)
+        .anyMatch(v -> v.getPropertyPath().toString().equals("email"));
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_電話番号の形式が {0} のときバリデーション違反が起きる")
+  @ValueSource(strings = {
+      "09000000000",     // ハイフンなし
+      "090-0000-000",    // 下4桁が3桁
+      "0900-000-00000",  // 中間と下桁の桁数異常
+      "abcd-efgh-ijkl",  // 数字以外
+      "-03-1234-5678",   // 先頭にハイフン
+      "03--1234-5678",   // ハイフン重複
+      "03-1234--5678"    // ハイフン重複（別位置）
+  })
+  void 登録時_電話番号の形式が不正のときバリデーション違反が起きる(String invalidPhoneNumber) {
+    // Arrange
+    Integer studentId = null;
+    Student invalidStudent = new Student(
+        studentId,
+        "山田太郎",
+        "やまだたろう",
+        "タロー",
+        "test@example.com",
+        "東京都",
+        invalidPhoneNumber,
+        20,
+        "男",
+        "備考なし",
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        CreateGroup.class);
+
+    // Assert
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream()
+        .anyMatch(v -> v.getPropertyPath().toString().equals("telephone"))).isTrue();
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_年齢が {0} のとき violation={1}")
+  @CsvSource({
+      "14,true",
+      "15,false",
+      "80,false",
+      "81,true"
+  })
+  void 登録時_年齢バリデーションの境界値テスト(int age,boolean expectViolation)
+      throws Exception {
+    // Arrange
+    Integer studentId = null;
+    Student invalidStudent = new Student(
+        studentId,
+        "山田太郎",
+        "やまだたろう",
+        "タロー",
+        "taro@email.com",
+        "東京都練馬区",
+        "090-0000-0000",
+        age,
+        "男",
+        "特になし",
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(
+        invalidStudent,
+        CreateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals("age"))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_性別が {0} のとき violation={1}")
+  @CsvSource({
+      "男,false",
+      "女,false",
+      "その他,false",
+      "男性,true",
+      "female,true",
+      "man,true",
+      "それ以外,true"
+  })
+  void 登録時_性別が想定されたパターンのときは通過しパターン外のときバリデーション違反になること(
+      String sex, boolean expectViolation) {
+    // Arrange
+    Integer studentId = null;
+    Student invalidStudent = new Student(
+        studentId,
+        "山田太郎",
+        "やまだたろう",
+        "タロー",
+        "test@example.com",
+        "東京都",
+        "090-0000-0000",
+        20,
+        sex,
+        "",
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        CreateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals("sex"))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @Test
+  void 登録時_Studentの各のフィールドが妥当な値を持つときバリデーション違反が起きない(){
+    Integer studentId = null;
+    Student validStudent = TestDataFactory.makeCompletedStudent(studentId);
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(validStudent,
+        CreateGroup.class);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest(name = "[{index}] 更新時_フィールド: {0} がnullのとき violation={1}")
+  @CsvSource({// trueはNotNull, falseはnull許容
+      "studentId,true",
+      "fullName,true",
+      "kanaName,true",
+      "nickname,true",
+      "email,true",
+      "area,false",
+      "telephone,false",
+      "age,false",
+      "sex,false",
+      "remark,false"
+  })
+  void 更新時_各フィールドのnull許容性のテスト(String fieldName,
+      boolean expectViolation) {
+    // Arrange
+    Student student = new Student(
+        fieldName.equals("studentId") ? null : 1,
+        fieldName.equals("fullName") ? null : "山田太郎",
+        fieldName.equals("kanaName") ? null : "やまだたろう",
+        fieldName.equals("nickname") ? null : "タロー",
+        fieldName.equals("email") ? null : "yamada@example.com",
+        fieldName.equals("area") ? null : "東京都",
+        fieldName.equals("telephone") ? null : "090-0000-0000",
+        fieldName.equals("age") ? null : 20,
+        fieldName.equals("sex") ? null : "男",
+        fieldName.equals("remark") ? null : "特になし",
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(student,
+        UpdateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals(fieldName))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @Test
+  void 更新時_studentIdが1未満の数値の時バリデーション違反_true() {
+    Integer studentId = -3;
+    Student invalidStudent = TestDataFactory.makeCompletedStudent(studentId);
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        UpdateGroup.class);
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream()
+        .anyMatch(v -> v.getPropertyPath().toString().equals("studentId"))).isTrue();
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_フィールド：{0}が上限50文字に対して{1}文字のとき violation={2}")
+  @CsvSource({
+      "fullName,49,false",
+      "fullName,50,false",
+      "fullName,51,true",
+
+      "kanaName,49,false",
+      "kanaName,50,false",
+      "kanaName,51,true",
+
+      "nickname,49,false",
+      "nickname,50,false",
+      "nickname,51,true",
+
+      "area,49,false",
+      "area,50,false",
+      "area,51,true",
+  })
+  void 更新時_50文字上限のフィールドの文字数の境界値テスト(String fieldName, int length, boolean expectViolation) throws Exception {
+    // Arrange
+    Integer studentId = 1;
+    String testValue = "あ".repeat(length);
+    Student invalidStudent = new Student(
+        studentId,
+        fieldName.equals("fullName") ? testValue : "山田太郎",
+        fieldName.equals("kanaName") ? testValue : "やまだたろう",
+        fieldName.equals("nickname") ? testValue : "タロー",
+        "test@example.com",
+        fieldName.equals("area") ? testValue : "東京都",
+        "090-0000-0000",
+        20,
+        "男",
+        "特になし",
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        UpdateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations)
+          .anyMatch(v -> v.getPropertyPath().toString().equals(fieldName));
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @ParameterizedTest(name = "[{index}] 登録時_フィールド：remark が上限200文字に対して{0}文字のとき violation={1}")
+  @CsvSource({
+      "199,false",
+      "200,false",
+      "201,true"
+  })
+  void 更新時_200文字上限のフィールドの文字数の境界値テスト(int length, boolean expectViolation) throws Exception {
+    // Arrange
+    Integer studentId = 1;
+    String testValue = "あ".repeat(length);
+    Student invalidStudent = new Student(
+        studentId,
+        "山田太郎",
+        "やまだたろう",
+        "タロー",
+        "test@example.com",
+        "東京都",
+        "090-0000-0000",
+        20,
+        "男",
+        testValue,
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        UpdateGroup.class);
+
+    // Assert
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations)
+          .anyMatch(v -> v.getPropertyPath().toString().equals("remark"));
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @ParameterizedTest(name = "[{index}] 更新時_emailの形式が {0} のとき violation={1}")
+  @ValueSource(strings = {
+      "plainaddress",        // @なし
+      "@missingusername.com",// ユーザー名なし
+      "username@.com",       // ドメイン名先頭にドット
+      "user@com.",           // ドメイン末尾にドット
+      "user@-com.com",       // 不正なドメイン記号
+      "user@com..com"        // ドット連続
+  })
+  void 更新時_emailの形式が不正な場合はバリデーション違反が起きる(String invalidEmail) {
+    // Arrange
+    Integer studentId = 1;
+    Student invalidStudent = new Student(
+        studentId, "山田太郎", "やまだたろう", "タロー", invalidEmail,
+        "東京都", "090-0000-0000", 20, "男", "", false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        UpdateGroup.class);
+
+    // Assert
+    assertThat(violations)
+        .anyMatch(v -> v.getPropertyPath().toString().equals("email"));
+  }
+
+  @ParameterizedTest(name = "[{index}] 更新時_電話番号の形式が {0} のとき violation={1}")
+  @ValueSource(strings = {
+      "09000000000",     // ハイフンなし
+      "090-0000-000",    // 下4桁が3桁
+      "0900-000-00000",  // 中間と下桁の桁数異常
+      "abcd-efgh-ijkl",  // 数字以外
+      "-03-1234-5678",   // 先頭にハイフン
+      "03--1234-5678",   // ハイフン重複
+      "03-1234--5678"    // ハイフン重複（別位置）
+  })
+  void 更新時_電話番号の形式が不正のときバリデーション違反が起きる(String invalidPhoneNumber) {
+    // Arrange
+    Integer studentId = 1;
+    Student invalidStudent = new Student(
+        studentId,
+        "山田太郎",
+        "やまだたろう",
+        "タロー",
+        "test@example.com",
+        "東京都",
+        invalidPhoneNumber,
+        20,
+        "男",
+        "備考なし",
+        false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        UpdateGroup.class);
+
+    // Assert
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream()
+        .anyMatch(v -> v.getPropertyPath().toString().equals("telephone"))).isTrue();
+  }
+
+  @ParameterizedTest(name = "[{index}] 更新時_年齢が {0} のとき violation={1}")
+  @CsvSource({
+      "14,true",
+      "15,false",
+      "80,false",
+      "81,true"
+  })
+  void 更新時_年齢バリデーションの境界値テスト(int age, boolean expectViolation)
+      throws Exception {
+    // Arrange
+    Integer studentId = 1;
+    Student invalidStudent = new Student(
+        studentId,
+        "山田太郎",
+        "やまだたろう",
+        "タロー",
+        "taro@email.com",
+        "東京都練馬区",
+        "090-0000-0000",
+        age,
+        "男",
+        "特になし",
+        false
+    );
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(
+        invalidStudent,
+        UpdateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals("age"))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+
+  @ParameterizedTest(name = "[{index}] 更新時_性別が ”{0}” のとき violation={1}")
+  @CsvSource({
+      "男,false",
+      "女,false",
+      "その他,false",
+      "男性,true",
+      "female,true",
+      "man,true",
+      "それ以外,true"
+  })
+  void 更新時_性別が想定されたパターンのとき通過しパターン外のときバリデーション違反が起きること(
+      String sex, boolean expectViolation) {
+    // Arrange
+    Integer studentId = 1;
+    Student invalidStudent = new Student(
+        studentId, "山田太郎", "やまだたろう", "タロー", "test@example.com",
+        "東京都", "090-0000-0000", 20, sex, "", false
+    );
+
+    // Act
+    Set<ConstraintViolation<Student>> violations = validator.validate(invalidStudent,
+        UpdateGroup.class);
+
+    // Assert
+    if (expectViolation) {
+      assertThat(violations).isNotEmpty();
+      assertThat(violations.stream()
+          .anyMatch(v -> v.getPropertyPath().toString().equals("sex"))).isTrue();
+    } else {
+      assertThat(violations).isEmpty();
+    }
+  }
+
+  @Test
+  void 更新時_Studentの各のフィールドが妥当な値を持つときバリデーション違反が起きない(){
+    Integer studentId = 1;
+    Student validStudent = TestDataFactory.makeCompletedStudent(studentId);
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(validStudent,
+        UpdateGroup.class);
+
+    assertThat(violations).isEmpty();
+  }
+
+
+}

--- a/src/test/java/raisetech/student/management/data/domain/StudentDetailTest.java
+++ b/src/test/java/raisetech/student/management/data/domain/StudentDetailTest.java
@@ -1,0 +1,131 @@
+package raisetech.student.management.data.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.testutil.TestDataFactory;
+import raisetech.student.management.validation.CreateGroup;
+import raisetech.student.management.validation.UpdateGroup;
+
+class StudentDetailTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUpValidator() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  void 登録時_受講生がnullのときバリデーション違反が起きる() {
+    // Arrange
+    Integer studentId = 1;
+    Integer courseId = 1;
+    StudentDetail invalidStudentDetail = new StudentDetail(
+        null, List.of(TestDataFactory.makeCompletedStudentCourse(studentId, courseId))
+    );
+    Set<ConstraintViolation<StudentDetail>> violations = validator.validate(
+        invalidStudentDetail, CreateGroup.class);
+
+    // Act & Assert
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream()
+        .anyMatch(v -> v.getPropertyPath().toString().equals("student"))).isTrue();
+    // studentCourseでviolationが発生しても、studentでのviolationが確認できれば良いのでanyMatch
+  }
+
+  @Test
+  void 登録時_受講生コースが空のときバリデーション違反が起きる() {
+    // Arrange
+    Integer studentId = 1;
+    StudentDetail invalidStudentDetail = new StudentDetail(
+        TestDataFactory.makeCompletedStudent(studentId), new ArrayList<StudentCourse>()
+    );
+    Set<ConstraintViolation<StudentDetail>> violations = validator.validate(
+        invalidStudentDetail, CreateGroup.class);
+
+    // Act & Assert
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream()
+        .anyMatch(v -> v.getPropertyPath().toString().equals("studentCourses"))).isTrue();
+  }
+
+  @Test
+  void 登録時_各フィールドが妥当な値をもつときバリデーション違反が起きない() {
+    // Arrange:
+    Integer studentId = null;
+    Integer courseId = null;
+    StudentDetail validStudentDetail = new StudentDetail(
+        TestDataFactory.makeCompletedStudent(studentId),
+        List.of(TestDataFactory.makeCompletedStudentCourse(studentId,courseId))
+    );
+    Set<ConstraintViolation<StudentDetail>> violations = validator.validate(
+        validStudentDetail, CreateGroup.class);
+
+    // Act & Assert
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void 更新時_受講生がnullのときバリデーション違反が起きる() {
+    // Arrange
+    Integer studentId = 1;
+    Integer courseId = 1;
+    StudentDetail invalidStudentDetailForm = new StudentDetail(
+        null, List.of(TestDataFactory.makeCompletedStudentCourse(studentId, courseId))
+    );
+    Set<ConstraintViolation<StudentDetail>> violations = validator.validate(
+        invalidStudentDetailForm,
+        UpdateGroup.class);
+
+    // Act & Assert
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream()
+        .anyMatch(v -> v.getPropertyPath().toString().equals("student"))).isTrue();
+    // studentCourseでviolationが発生しても、studentでのviolationが確認できれば良いのでanyMatch
+  }
+
+  @Test
+  void 登録時および更新時_受講生コースが空のときバリデーション違反が起きる() {
+    // Arrange
+    Integer studentId = 1;
+    StudentDetail invalidStudentDetail = new StudentDetail(
+        TestDataFactory.makeCompletedStudent(studentId), new ArrayList<StudentCourse>()
+    );
+    Set<ConstraintViolation<StudentDetail>> violations = validator.validate(
+        invalidStudentDetail,
+        UpdateGroup.class);
+
+    // Act & Assert
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream()
+        .anyMatch(v -> v.getPropertyPath().toString().equals("studentCourses"))).isTrue();
+  }
+
+
+  @Test
+  void 更新時_各フィールドが妥当な値をもつときバリデーション違反が起きない() {
+    // Arrange:
+    Integer studentId = 1;
+    Integer courseId = 1;
+    StudentDetail validStudentDetail = new StudentDetail(
+        TestDataFactory.makeCompletedStudent(studentId),
+        List.of(TestDataFactory.makeCompletedStudentCourse(studentId,courseId))
+    );
+    Set<ConstraintViolation<StudentDetail>> violations = validator.validate(
+        validStudentDetail,
+        UpdateGroup.class);
+
+    // Act & Assert
+    assertThat(violations).isEmpty();
+  }
+
+}

--- a/src/test/java/raisetech/student/management/testutil/TestDataFactory.java
+++ b/src/test/java/raisetech/student/management/testutil/TestDataFactory.java
@@ -8,17 +8,17 @@ import raisetech.student.management.data.domain.StudentDetail;
 
 public class TestDataFactory {
 
-  public static Student makeCompletedStudent(int studentId) {
+  public static Student makeCompletedStudent(Integer studentId) {
     return new Student(studentId, "山田太郎", "やまだたろう", "タロー", "taro@email.com",
         "東京都練馬区", "090-0000-0000", 20, "男", "特になし", false);
   }
 
-  public static StudentCourse makeCompletedStudentCourse(int studentId, int courseId) {
+  public static StudentCourse makeCompletedStudentCourse(Integer studentId, Integer courseId) {
     LocalDate now = LocalDate.now();
     return new StudentCourse(courseId, studentId, "Javaコース",  now, now.plusYears(1));
   }
 
-  public static StudentDetail makeCompletedStudentDetail(int studentId, int courseId) {
+  public static StudentDetail makeCompletedStudentDetail(Integer studentId, Integer courseId) {
     return new StudentDetail(makeCompletedStudent(studentId),
         List.of(makeCompletedStudentCourse(studentId, courseId)));
   }


### PR DESCRIPTION
## 〇 概要
`StudentController`のWebMvcテストと、`Student`,`StudentCourse`,`StudentDetail`各オブジェクトのバリデーションが効いているかを検証するテストを実装しました。

## 〇 実装内容
### ▼ SpringMvcのテスト
`StudentController`クラスに対するWebMvcTestとして`StudentControllerTest`クラスを作成しました
`StudentController`のエンドポイントに対して、リクエスト時の入力やサービス層の返り値に応じて、HTTPステータス / レスポンスJSON が期待通りになることを検証しました。

### ▼ 各オブジェクトのバリデーションのテスト
`Student`、`StudentCourse`、`StudentDetail` 各クラスに対するバリデーションテストを作成しました。  
妥当な値では違反が発生しないこと、不正な値では想定したフィールドに違反が発生することを検証しました。

## 〇 動作確認(テストサマリー)
→ 既存/新規ともにすべてのテストが成功確認　CIでも全テスト成功
<img width="991" height="577" alt="image" src="https://github.com/user-attachments/assets/3d21abd5-3a38-4ea3-8e20-763de2f5344b" />

### 既存のテスト
<img width="988" height="578" alt="image" src="https://github.com/user-attachments/assets/88df6be5-7e91-4100-bdab-eb6be5ba12b3" />

### 新規のテスト
#### ▼ StudentControllerTest
<img width="974" height="587" alt="image" src="https://github.com/user-attachments/assets/5e83fee1-d530-423a-b838-ba1c09d909e6" />

#### ▼ StudentDetailTest
<img width="989" height="579" alt="image" src="https://github.com/user-attachments/assets/2dfa215c-2227-4807-9928-cff4c4a40628" />

#### ▼ StudentTest
<img width="1052" height="567" alt="image" src="https://github.com/user-attachments/assets/77ba5dcc-4cd7-4232-89dc-2a478717a5ac" />
<img width="1054" height="578" alt="image" src="https://github.com/user-attachments/assets/cc883dfe-c292-4e3f-a2d8-84c6936cf562" />
<img width="1053" height="544" alt="image" src="https://github.com/user-attachments/assets/d875c48a-8cf8-439e-aa8b-b2e79e492491" />
<img width="1055" height="172" alt="image" src="https://github.com/user-attachments/assets/743afb36-c4e0-45ac-9fa0-d53b94ba142f" />

#### ▼ StudentCourseTest
<img width="1068" height="572" alt="image" src="https://github.com/user-attachments/assets/4d3e2843-3c90-4845-9390-a68abcb75a36" />

## 〇 工夫した点・学んだこと

- Spring Boot 4 系の現在の構成では、`spring-boot-starter-test` のみでは `@WebMvcTest` 関連のテストが解決できなかったため、`spring-boot-starter-webmvc-test` を追加しました。
- 当初の設定では、GitHub Actions上でのCI実行時に、本当にすべてのテストが実施されPASSしているかがログから把握できなかったため、`build.gradle`に詳細ログ出力の設定を追記しました。これにより、[Run Tests]のログにテスト実行件数と、すべてのテストメソッド名と実行結果（`PASSED`,`FAILED`,`SKIPPED`）が網羅的に記述されるようになりました。
- 【追記】PR作成時当初は、`StudentControllerTest`において、登録・更新系メソッドのテストにおいて、事前作成したオブジェクトを`ObjectMapper`でJSONシリアライズしたものをリクエストボディとして渡していましたが、そのままJSON文字列で記述したリクエストボディを渡すように変更しました。理由は、@WebMvcTestはHTTPリクエストを受け取るControllerの振る舞いを検証するテストであるため、Javaオブジェクトではなく実際のリクエスト形式であるJSONを明示的に記述した方がテストの意図が明確になると考えたためです。