### PR TITLE
[課題54] CDの設定

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
   deploy:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'feature' &&
+      github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,8 +51,8 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{ vars.EC2_HOST }}
-          username: ${{ vars.EC2_USE }}
-          key: ${{secrets.AWS_EC2_PRIVATE_KEY}}
+          username: ${{ vars.EC2_USER }}
+          key: ${{ secrets.AWS_EC2_PRIVATE_KEY }}
           envs: DEST_PATH
           script: |
             sudo yum update -y

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,85 @@
+name: CD with Gradle
+
+on:
+  workflow_run:
+    workflows: [ "Java CI with Gradle" ]
+    types:
+      - completed
+
+env:
+  SRC_PATH: 'build/libs/*.jar'
+  DEST_PATH: '/home/ec2-user/StudentManagement.jar'
+
+jobs:
+  deploy:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'feature' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew bootJar
+
+      - name: SCP Copy Application to EC2
+        env:
+          PRIVATE_KEY: ${{ secrets.AWS_EC2_PRIVATE_KEY }}
+          EC2_HOST: ${{ vars.EC2_HOST }}
+          EC2_USER: ${{ vars.EC2_USER }}
+        run: |
+          echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
+          scp -o StrictHostKeyChecking=no -i private_key $SRC_PATH $EC2_USER@$EC2_HOST:$DEST_PATH
+
+      - name: SSH Application Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ vars.EC2_HOST }}
+          username: ${{ vars.EC2_USE }}
+          key: ${{secrets.AWS_EC2_PRIVATE_KEY}}
+          envs: DEST_PATH
+          script: |
+            sudo yum update -y
+            if [ -f /etc/systemd/system/StudentManagement.service ]; then
+              echo "already exists Service File"
+            else
+            cat << EOL | sudo tee /etc/systemd/system/StudentManagement.service
+            [Unit]
+            Description = StudentManagement App
+            
+            [Service]
+            ExecStart = java -jar ${DEST_PATH}
+            EnvironmentFile = /etc/sysconfig/StudentManagement
+            Restart = no
+            Type = simple
+            User = ec2-user
+            Group = ec2-user
+            SuccessExitStatus = 143
+            
+            [Install]
+            WantedB = multi-user.target
+            EOL
+            fi
+            
+            sudo systemctl daemon-reload
+            if sudo systemctl status StudentManagement 2>&1 | grep "Active: active (running)" ; then
+              sudo systemctl restart StudentManagement
+            else
+              sudo systemctl start StudentManagement
+            fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,28 +56,6 @@ jobs:
           envs: DEST_PATH
           script: |
             sudo yum update -y
-            if [ -f /etc/systemd/system/StudentManagement.service ]; then
-              echo "already exists Service File"
-            else
-            cat << EOL | sudo tee /etc/systemd/system/StudentManagement.service
-            [Unit]
-            Description = StudentManagement App
-            
-            [Service]
-            ExecStart = java -jar ${DEST_PATH}
-            EnvironmentFile = /etc/sysconfig/StudentManagement
-            Restart = no
-            Type = simple
-            User = ec2-user
-            Group = ec2-user
-            SuccessExitStatus = 143
-            
-            [Install]
-            WantedB = multi-user.target
-            EOL
-            fi
-            
-            sudo systemctl daemon-reload
             if sudo systemctl status StudentManagement 2>&1 | grep "Active: active (running)" ; then
               sudo systemctl restart StudentManagement
             else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Java CI with Gradle
 
 on:
   push:
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -17,10 +19,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "21"
-          cache: "gradle"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Run tests
+      - name: Test with Gradle Wrapper
         run: ./gradlew test --no-daemon --stacktrace


### PR DESCRIPTION
## 〇 概要
デプロイメントの確実性と再現性を担保するために、CDを設定し手順を自動化しました。

## 〇 実装内容
### ◎ CD設定ファイルを新規作成
以下の主な処理を実行するymlファイルを記述しました。
- プロジェクトのJARファイルを作成し、EC2にコピーする
- EC2にSSH接続
- EC2上でコマンドを実行し、`StudentManagement`サービスが停止中なら起動、すでに起動中なら再起動する

### ◎ CI設定ファイルをリファクタリング
- Gradleセットアップ方法をCD設定ファイルに合わせて独立ステップとして記述
- GitHub Actions に与える権限を`read`として明示
- ワークフロー名やステップ名のリネーム

## 〇 動作確認
一時的にdefault branchおよびCD発火対象をfeatureブランチに設定した [308eead](https://github.com/saway261/StudentManagement/pull/14/commits/308eead5e9d24b51be8c951d3d386c08547d213c) までのコミットで、動作確認を行いました。

①コミット`308eead`のpushをトリガーに実行されたCI完了後にCDが実行されていることを確認
<img width="679" height="122" alt="image" src="https://github.com/user-attachments/assets/33b8a114-d321-4fb0-99ce-63656633df72" />
<img width="771" height="796" alt="image" src="https://github.com/user-attachments/assets/ce57905f-7801-46f9-ad65-bb0d2c797d98" />
<img width="774" height="848" alt="image" src="https://github.com/user-attachments/assets/fce99a37-dcd6-4bf1-a4dc-01f0af0f8e70" />

②[313b173](https://github.com/saway261/StudentManagement/pull/14/commits/313b173845ed73ef23ebf0bfe6a5a4132e8bc5a1)までのコミットでEC2インスタンス内に正常に`StudentManagement.service`が作成されていることを確認
```linux
[root@ip-10-0-4-190 ~]# cat /etc/systemd/system/StudentManagement.service
[Unit]
Description = StudentManagement App

[Service]
ExecStart = java -jar /home/ec2-user/StudentManagement.jar
EnvironmentFile = /etc/sysconfig/StudentManagement
Restart = no
Type = simple
User = ec2-user
Group = ec2-user
SuccessExitStatus = 143

[Install]
WantedB = multi-user.target
```

③EC2インスタンスのステータスから、アプリケーションが稼働していることを確認
```linux
[ec2-user@ip-10-0-4-190 ~]$ sudo systemctl status StudentManagement.service
● StudentManagement.service - StudentManagement App
     Loaded: loaded (/etc/systemd/system/StudentManagement.service; static)
     Active: active (running) since Thu 2026-04-16 08:38:33 UTC; 1h 5min ago
   Main PID: 6308 (java)
      Tasks: 31 (limit: 1043)
     Memory: 195.0M
        CPU: 26.936s
     CGroup: /system.slice/StudentManagement.service
             └─6308 java -jar /home/ec2-user/StudentManagement.jar

Apr 16 08:38:40 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:38:40.667Z  INFO 6308 --- [student.>
Apr 16 08:38:40 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:38:40.688Z  INFO 6308 --- [student.>
Apr 16 08:38:40 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:38:40.695Z  WARN 6308 --- [student.>
Apr 16 08:38:40 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:38:40.696Z  WARN 6308 --- [student.>
Apr 16 08:38:51 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:38:51.839Z  INFO 6308 --- [student.>
Apr 16 08:38:51 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:38:51.839Z  INFO 6308 --- [student.>
Apr 16 08:38:51 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:38:51.843Z  INFO 6308 --- [student.>
Apr 16 08:40:04 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:40:04.246Z  INFO 6308 --- [student.>
Apr 16 08:40:04 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:40:04.984Z  INFO 6308 --- [student.>
Apr 16 08:40:04 ip-10-0-4-190.ap-northeast-1.compute.internal java[6308]: 2026-04-16T08:40:04.988Z  INFO 6308 --- [student.>
lines 1-20/20 (END)
```

④PostmanからAPIに対してリクエストを送り、疎通確認
<img width="951" height="712" alt="image" src="https://github.com/user-attachments/assets/c56ccd50-ccf4-42d3-ab48-8a89df2fb33f" />

## 〇 工夫した点・学んだこと
### ◎ CIとCDそれぞれの設定ファイルを分離
`ci.yml`と`cd.yml`を独立して作成することで、それぞれの実行内容が明確になるとともに、発火タイミングを細かく設定できるようにしました。
たとえば、CI（テスト）はすべてのブランチへのpush、またはPRの作成・更新・再オープン時に実行されます。これにより、変更内容を早い段階で検証でき、不具合の早期発見と修正が可能になります。
一方で、CD（デプロイ）はmainブランチへのpushをトリガーとして成功終了したときに実行されます。これにより、テストを通過したコードのみがデプロイ対象となり、本番環境への反映の安全性と信頼性が担保されます。

### ◎ Repository variablesの活用
EC2インスタンスのパブリックIPv4アドレスが変更されると`cd.yml`でEC2ホスト名を修正しなければならず、今後も機能追加や改修のたびにこの部分の修正が必要になることが予測されます。PRの本題に関係ない差分が混ざることを避けるため、`$EC2_HOST`,`$EC2_USER`をGitHubのRepository variablesで管理するようにしました。
<img width="601" height="167" alt="image" src="https://github.com/user-attachments/assets/10f0312e-6c70-487b-b82b-4109ce3a461c" />
